### PR TITLE
'借りた'メッセージを受け取った時にlendingsテーブルにレコードを新規追加するようにした

### DIFF
--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DataSourceManagerImpl" format="xml" multifile-model="true">
+    <data-source source="LOCAL" name="PostgreSQL - intern_line_bot@localhost" uuid="2d95c9c7-b4d3-410c-a33a-5dbbaf83ca5d">
+      <driver-ref>postgresql</driver-ref>
+      <synchronize>true</synchronize>
+      <jdbc-driver>org.postgresql.Driver</jdbc-driver>
+      <jdbc-url>jdbc:postgresql://localhost:5432/intern_line_bot</jdbc-url>
+      <working-dir>$ProjectFileDir$</working-dir>
+    </data-source>
+  </component>
+</project>

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -1,13 +1,8 @@
-require 'line/bot'
-
 class WebhookController < ApplicationController
   protect_from_forgery except: [:callback] # CSRF対策無効化
 
   def client
-    @client ||= Line::Bot::Client.new do |config|
-      config.channel_secret = ENV["LINE_CHANNEL_SECRET"]
-      config.channel_token = ENV["LINE_CHANNEL_TOKEN"]
-    end
+    @client ||= WebhookHelper::LineBotClient.new
   end
 
   def callback

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -29,7 +29,7 @@ class WebhookController < ApplicationController
               if action == "借りた"
                 Lending.create!(borrower_id: borrower_id, lender_name: lender_name, content: content)
 
-                lending_count = Lending.where(borrower_id: borrower_id, lender_name: lender_name).count
+                lending_count = Lending.not_returned.where(borrower_id: borrower_id, lender_name: lender_name).count
                 "#{lender_name}さんに#{content}を借りました！\n#{lender_name}さんには計#{lending_count}個の借りがあります。"
 
               elsif action == "一覧"

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -44,11 +44,14 @@ class WebhookController < ApplicationController
 
             client.reply_message(reply_token, { type: 'text', text: response })
           rescue => error
-            logger.error error
+            response =
+              if error.is_a?(ArgumentError)
+                "エラーが発生しました。入力値が間違っている可能性があります。"
+              else
+                logger.error error
+                " 予期せぬエラーが発生しました。"
+              end
 
-            response = error.is_a?(ArgumentError) ?
-                         "エラーが発生しました。入力値が間違っている可能性があります。" :
-                         " 予期せぬエラーが発生しました。"
             client.reply_message(reply_token, { type: 'text', text: response })
           end
         else

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -37,8 +37,8 @@ class WebhookController < ApplicationController
 
                 Lending.create!(borrower_id: borrower_id, lender_name: lender_name, content: content)
 
-                count_lendings = Lending.where(borrower_id: borrower_id, lender_name: lender_name).count
-                "#{lender_name}さんに#{content}を借りました！\n#{lender_name}さんには計#{count_lendings}個の借りがあります。"
+                lending_count = Lending.where(borrower_id: borrower_id, lender_name: lender_name).count
+                "#{lender_name}さんに#{content}を借りました！\n#{lender_name}さんには計#{lending_count}個の借りがあります。"
 
               elsif messages[0] == "一覧" && messages.length == 1
                 '佐藤くん(2個)　100円　マスタリングTCP/IP借りた、田中くん(1個)　研究の調査を手伝ってもらった、......'

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -28,23 +28,20 @@ class WebhookController < ApplicationController
         case event.type
         when Line::Bot::Event::MessageType::Text
           begin
-            messages = event.message['text'].split(/[\s　]+/)
+            action, lender_name, content = event.message['text'].split(/[\s　]+/)
 
             response =
-              if messages[0] == "借りた" && messages.length == 3
-                lender_name = messages[1]
-                content = messages[2]
-
+              if action == "借りた"
                 Lending.create!(borrower_id: borrower_id, lender_name: lender_name, content: content)
 
                 lending_count = Lending.where(borrower_id: borrower_id, lender_name: lender_name).count
                 "#{lender_name}さんに#{content}を借りました！\n#{lender_name}さんには計#{lending_count}個の借りがあります。"
 
-              elsif messages[0] == "一覧" && messages.length == 1
+              elsif action == "一覧"
                 '佐藤くん(2個)　100円　マスタリングTCP/IP借りた、田中くん(1個)　研究の調査を手伝ってもらった、......'
 
-              elsif messages[0] == "返した" && messages.length == 3
-                "#{messages[2]}さんに#{messages[1]}を返しました！"
+              elsif action == "返した"
+                "#{lender_name}さんに#{content}を返しました！"
 
               else
                 raise RuntimeError

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -21,7 +21,7 @@ class WebhookController < ApplicationController
     events = client.parse_events_from(body)
     events.each do |event|
       reply_token = event['replyToken']
-      user_id = event['source']['userId']
+      borrower_id = event['source']['userId']
 
       case event
       when Line::Bot::Event::Message
@@ -35,9 +35,9 @@ class WebhookController < ApplicationController
                 lender_name = messages[1]
                 content = messages[2]
 
-                Lending.create!(borrower_id: user_id, lender_name: lender_name, content: content)
+                Lending.create!(borrower_id: borrower_id, lender_name: lender_name, content: content)
 
-                count_lendings = Lending.where("borrower_id = ?", user_id).where("lender_name = ?", lender_name).count
+                count_lendings = Lending.where("borrower_id = ?", borrower_id).where("lender_name = ?", lender_name).count
                 "#{lender_name}さんに#{content}を借りました！\n#{lender_name}さんには計#{count_lendings}個の借りがあります。"
 
               elsif messages[0] == "一覧" && messages.length == 1

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -2,7 +2,7 @@ class WebhookController < ApplicationController
   protect_from_forgery except: [:callback] # CSRF対策無効化
 
   def client
-    @client ||= WebhookHelper::LineBotClient.new
+    @client ||= LineBotClient.generate
   end
 
   def callback
@@ -26,7 +26,7 @@ class WebhookController < ApplicationController
 
           begin
             response =
-              if action == "借りた"
+              if action == "借りた" && lender_name && content
                 Lending.create!(borrower_id: borrower_id, lender_name: lender_name, content: content)
 
                 lending_count = Lending.not_returned.where(borrower_id: borrower_id, lender_name: lender_name).count
@@ -35,11 +35,11 @@ class WebhookController < ApplicationController
               elsif action == "一覧"
                 '佐藤くん(2個)　100円　マスタリングTCP/IP借りた、田中くん(1個)　研究の調査を手伝ってもらった、......'
 
-              elsif action == "返した"
+              elsif action == "返した" && lender_name && content
                 "#{lender_name}さんに#{content}を返しました！"
 
               else
-                raise ArgumentError, "Unexpected action: #{action}"
+                raise ArgumentError, "Invalid parameters: action:#{action}"
               end
 
             client.reply_message(reply_token, { type: 'text', text: response })

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -51,7 +51,8 @@ class WebhookController < ApplicationController
               end
 
             client.reply_message(reply_token, { type: 'text', text: response })
-          rescue
+          rescue => e
+            puts e
             client.reply_message(
               reply_token,
               { type: 'text', text: "エラーが発生しました。入力値が間違っている可能性があります。" }

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -37,7 +37,7 @@ class WebhookController < ApplicationController
 
                 Lending.create!(borrower_id: borrower_id, lender_name: lender_name, content: content)
 
-                count_lendings = Lending.where("borrower_id = ?", borrower_id).where("lender_name = ?", lender_name).count
+                count_lendings = Lending.where(borrower_id: borrower_id, lender_name: lender_name).count
                 "#{lender_name}さんに#{content}を借りました！\n#{lender_name}さんには計#{count_lendings}個の借りがあります。"
 
               elsif messages[0] == "一覧" && messages.length == 1

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -43,16 +43,11 @@ class WebhookController < ApplicationController
               end
 
             client.reply_message(reply_token, { type: 'text', text: response })
+          rescue ArgumentError => error
+            client.reply_message(reply_token, { type: 'text', text: "エラーが発生しました。入力値が間違っている可能性があります。" })
           rescue => error
-            response =
-              if error.is_a?(ArgumentError)
-                "エラーが発生しました。入力値が間違っている可能性があります。"
-              else
-                logger.error error
-                " 予期せぬエラーが発生しました。"
-              end
-
-            client.reply_message(reply_token, { type: 'text', text: response })
+            logger.error error
+            client.reply_message(reply_token, { type: 'text', text: " 予期せぬエラーが発生しました。" })
           end
         else
           client.reply_message(reply_token, { type: 'text', text: 'そのメッセージ形式はサポートされていません' })

--- a/app/helpers/webhook_helper.rb
+++ b/app/helpers/webhook_helper.rb
@@ -1,0 +1,12 @@
+require 'line/bot'
+
+module WebhookHelper
+  class LineBotClient
+    def self.new
+      Line::Bot::Client.new do |config|
+        config.channel_secret = ENV["LINE_CHANNEL_SECRET"]
+        config.channel_token = ENV["LINE_CHANNEL_TOKEN"]
+      end
+    end
+  end
+end

--- a/app/helpers/webhook_helper.rb
+++ b/app/helpers/webhook_helper.rb
@@ -1,12 +1,2 @@
-require 'line/bot'
-
 module WebhookHelper
-  class LineBotClient
-    def self.new
-      Line::Bot::Client.new do |config|
-        config.channel_secret = ENV["LINE_CHANNEL_SECRET"]
-        config.channel_token = ENV["LINE_CHANNEL_TOKEN"]
-      end
-    end
-  end
 end

--- a/app/models/lending.rb
+++ b/app/models/lending.rb
@@ -1,3 +1,5 @@
 class Lending < ApplicationRecord
   validates :borrower_id, :lender_name, :content, presence: true
+
+  scope :not_returned, -> { where(has_returned: false) }
 end

--- a/app/models/line_bot_client.rb
+++ b/app/models/line_bot_client.rb
@@ -1,0 +1,10 @@
+require 'line/bot'
+
+class LineBotClient
+  def self.generate
+    Line::Bot::Client.new do |config|
+      config.channel_secret = ENV["LINE_CHANNEL_SECRET"]
+      config.channel_token = ENV["LINE_CHANNEL_TOKEN"]
+    end
+  end
+end


### PR DESCRIPTION
## 実装の背景・目的
'借りた'メッセージを受け取った際にDBに保存するようにしました。
エラー処理のやり方が適切かどうか不安なので見てほしいです。

## やったこと
- `Lending.create!`を使ってDBにデータを保存
- レスポンスメッセージに、そのときの貸してくれた人からの借りの合計数を含めるようにした。
- 保存時にエラーが発生したらエラーメッセージを返すようにした

## キャプチャ
![スクリーンショット 2021-05-25 14 38 37](https://user-images.githubusercontent.com/54694030/119444893-e61e6e80-bd66-11eb-8cb8-b5f8cd80c936.png)

## 補足
- `.idea/dataSources.xml`はRubyMineのDB接続の設定ファイルです