### PR TITLE
返却処理を実装した

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -42,7 +42,23 @@ class WebhookController < ApplicationController
                 render_to_string partial: 'list_per_lender', locals: { lending_per_lender: lending_per_lender }
 
               elsif action == "返した"
-                "#{lender_name}さんに#{content}を返しました！"
+                lending = Lending
+                            .not_returned
+                            .where(borrower_id: borrower_id, lender_name: lender_name, content: content)
+                            .order(:created_at)
+                            .first
+
+                raise(
+                  ArgumentError,
+                  "Lending was not found.\n
+                   borrower_id: #{borrower_id}, lender_name: #{lender_name}, content: #{content}"
+                ) if lending.nil?
+
+                lending.has_returned = true
+                lending.save!
+
+                lending_count = Lending.not_returned.where(borrower_id: borrower_id, lender_name: lender_name).count
+                "#{lender_name}さんに#{content}を返しました！\n#{lender_name}さんには計#{lending_count}個の借りがあります。"
 
               else
                 raise ArgumentError, "Unexpected action: #{action}"

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -46,8 +46,7 @@ class WebhookController < ApplicationController
 
                 raise ArgumentError if lending.nil?
 
-                lending.has_returned = true
-                lending.save!
+                lending.return_content!
 
                 lending_count = Lending.not_returned.where(borrower_id: borrower_id, lender_name: lender_name).count
                 "#{lender_name}さんに#{content}を返しました！\n#{lender_name}さんには計#{lending_count}個の借りがあります。"

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -44,11 +44,7 @@ class WebhookController < ApplicationController
                             .order(:created_at)
                             .first
 
-                raise(
-                  ArgumentError,
-                  "Lending was not found.\n
-                   borrower_id: #{borrower_id}, lender_name: #{lender_name}, content: #{content}"
-                ) if lending.nil?
+                raise ArgumentError if lending.nil?
 
                 lending.has_returned = true
                 lending.save!
@@ -57,7 +53,7 @@ class WebhookController < ApplicationController
                 "#{lender_name}さんに#{content}を返しました！\n#{lender_name}さんには計#{lending_count}個の借りがあります。"
 
               else
-                raise ArgumentError, "Invalid parameters: action:#{action}"
+                raise ArgumentError
               end
 
             client.reply_message(reply_token, { type: 'text', text: response })

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -38,13 +38,7 @@ class WebhookController < ApplicationController
                 render_to_string partial: 'list_per_lender', locals: { lendings_per_lender_content: lendings_per_lender_content }
 
               elsif action == "返した" && lender_name && content
-                lending = Lending
-                            .not_returned
-                            .where(borrower_id: borrower_id, lender_name: lender_name, content: content)
-                            .order(:created_at)
-                            .first
-
-                raise ArgumentError if lending.nil?
+                lending = Lending.not_returned.find_by!(borrower_id: borrower_id, lender_name: lender_name, content: content)
 
                 lending.return_content!
 
@@ -56,7 +50,7 @@ class WebhookController < ApplicationController
               end
 
             client.reply_message(reply_token, { type: 'text', text: response })
-          rescue ArgumentError => error
+          rescue ArgumentError, ActiveRecord::RecordNotFound => error
             client.reply_message(reply_token, { type: 'text', text: "エラーが発生しました。入力値が間違っている可能性があります。" })
           rescue => error
             logger.error error

--- a/app/models/lending.rb
+++ b/app/models/lending.rb
@@ -7,6 +7,10 @@ class Lending < ApplicationRecord
     group(:lender_name, :content).select("lender_name, content, count(*)")
   }
 
+  def return_content!
+    update!(has_returned: true)
+  end
+
   def self.format_per_lender_content_count(per_lender_content_counts)
     per_lender_content_counts.each_with_object({}) do |lending, hash|
       lender = lending.lender_name


### PR DESCRIPTION
## 実装の背景・目的
機能仕様レベル2の返却処理を実装しました。
47-51行目あたりのLendingが見つからなかった際のエラー処理のやり方が適切かどうか不安なのでみていただきたいです.

## やったこと
- "返した" メッセージを受け取った際にパラメータの貸した人と借りたものに一致するlendingsのレコードを取得する
- レコードが見つからなければパラメータが間違っていると判断し、エラーメッセージを返す
- レコードが見つかればhas_returnedカラムをtrueにし、返却の登録を行う
- その貸した人からの残りの借りたものの数を取得する
- ユーザーに正しく返却が行われたことと、残りの借りているものの数を返す


## キャプチャ
![スクリーンショット 2021-05-27 15 51 49](https://user-images.githubusercontent.com/54694030/119779269-75608900-bf03-11eb-8474-74177f0fc26c.png)

## 補足
