### PR TITLE
thankings と lending_thankings テーブルのマイグレーションを作成しました

### DIFF
--- a/db/migrate/20210526012850_create_thankings.rb
+++ b/db/migrate/20210526012850_create_thankings.rb
@@ -1,0 +1,11 @@
+class CreateThankings < ActiveRecord::Migration[6.0]
+  def change
+    create_table :thankings do |t|
+      t.string :name
+      t.string :url
+      t.references :lending, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210527084814_create_lending_thankings.rb
+++ b/db/migrate/20210527084814_create_lending_thankings.rb
@@ -1,0 +1,14 @@
+class CreateLendingThankings < ActiveRecord::Migration[6.0]
+  def change
+    create_table :lending_thankings do |t|
+      t.references :lending, null: false, foreign_key: true
+      t.references :thanking, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    change_table :thankings do |t|
+      t.remove_references :lending
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_26_012850) do
+ActiveRecord::Schema.define(version: 2021_05_27_084814) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "lending_thankings", force: :cascade do |t|
+    t.bigint "lending_id", null: false
+    t.bigint "thanking_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["lending_id"], name: "index_lending_thankings_on_lending_id"
+    t.index ["thanking_id"], name: "index_lending_thankings_on_thanking_id"
+  end
 
   create_table "lendings", force: :cascade do |t|
     t.string "borrower_id", null: false
@@ -27,10 +36,8 @@ ActiveRecord::Schema.define(version: 2021_05_26_012850) do
   create_table "thankings", force: :cascade do |t|
     t.string "name"
     t.string "url"
-    t.bigint "lending_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["lending_id"], name: "index_thankings_on_lending_id"
   end
 
   create_table "widgets", force: :cascade do |t|
@@ -41,5 +48,6 @@ ActiveRecord::Schema.define(version: 2021_05_26_012850) do
     t.datetime "updated_at", null: false
   end
 
-  add_foreign_key "thankings", "lendings"
+  add_foreign_key "lending_thankings", "lendings"
+  add_foreign_key "lending_thankings", "thankings"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_24_072729) do
+ActiveRecord::Schema.define(version: 2021_05_26_012850) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,6 +24,15 @@ ActiveRecord::Schema.define(version: 2021_05_24_072729) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "thankings", force: :cascade do |t|
+    t.string "name"
+    t.string "url"
+    t.bigint "lending_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["lending_id"], name: "index_thankings_on_lending_id"
+  end
+
   create_table "widgets", force: :cascade do |t|
     t.string "name"
     t.text "description"
@@ -32,4 +41,5 @@ ActiveRecord::Schema.define(version: 2021_05_24_072729) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "thankings", "lendings"
 end

--- a/document/er.puml
+++ b/document/er.puml
@@ -3,6 +3,7 @@
 hide circle
 skinparam inetype ortho
 
+' 借り
 entity Lending {
     +id: int
     --
@@ -14,6 +15,7 @@ entity Lending {
     #udpated_at: timestamp
 }
 
+' お礼
 entity Thanking {
     +id: int
     --
@@ -22,7 +24,15 @@ entity Thanking {
     #url: string
 }
 
-Lending ||--|| Thanking
+entity LendingThanking {
+    +id: int
+    --
+    ~lending_id: int
+    ~thanking_id: int
+}
+
+Lending ||--o{ LendingThanking
+Thanking ||--o{ LendingThanking
 
 entity Example {
     +primary_key: type


### PR DESCRIPTION
## 実装の背景・目的
thankings(お礼)テーブルとlending_thankings(借りとお礼の関連付け)テーブルを作成しました。

## やったこと
- thankingsテーブルのマイグレーションの作成
  - name: お礼の表示名
  - url: お礼のURL(例: https://giftee.com/items/952 )。ユーザーにリンクとして送り、タップしてそこでお礼を自分で買って貸した人に送ってもらう。
- lending_thankginsテーブルのマイグレーションの作成

## キャプチャ


## 補足
- 最初に間違ってlendingsとthankingsを一対一に関連づける想定でマイグレーションを作って後から中間テーブルを作る設計に修正したため、`20210526012850_create_thankings.rb`ではthankingsテーブルにlendingへのreferncesがあり、`20210527084814_create_lending_thankings.rb `でそれを削除するようになっています。