### PR TITLE
Thanking, LendingThankingモデルのバリデーションテストを作成しました

### DIFF
--- a/test/fixtures/lending_thankings.yml
+++ b/test/fixtures/lending_thankings.yml
@@ -1,9 +1,9 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  name: MyString
-  url: MyString
+  lending: one
+  thanking: one
 
 two:
-  name: MyString
-  url: MyString
+  lending: two
+  thanking: two

--- a/test/fixtures/thankings.yml
+++ b/test/fixtures/thankings.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  url: MyString
+  lending: one
+
+two:
+  name: MyString
+  url: MyString
+  lending: two

--- a/test/models/lending_thanking_test.rb
+++ b/test/models/lending_thanking_test.rb
@@ -5,4 +5,14 @@ class LendingThankingTest < ActiveSupport::TestCase
     lending_thanking = LendingThanking.new(lending_id: lendings(:one).id, thanking_id: thankings(:one).id)
     assert lending_thanking.valid?
   end
+
+  test 'lending_id must be presence' do
+    lending_thanking = LendingThanking.new(thanking_id: thankings(:one).id)
+    assert_not lending_thanking.valid?
+  end
+
+  test 'thanking_id must be presence' do
+    lending_thanking = LendingThanking.new(lending_id: lendings(:one).id)
+    assert_not lending_thanking.valid?
+  end
 end

--- a/test/models/lending_thanking_test.rb
+++ b/test/models/lending_thanking_test.rb
@@ -15,4 +15,32 @@ class LendingThankingTest < ActiveSupport::TestCase
     lending_thanking = LendingThanking.new(lending_id: lendings(:one).id)
     assert_not lending_thanking.valid?
   end
+
+  test 'lending_id must be associated exist lending' do
+    lending_ids = lendings.map(&:id)
+    not_exist_lending_id = generate_not_repeatable_id(lending_ids)
+
+    thanking = LendingThanking.new(lending_id: not_exist_lending_id, thanking_id: thankings(:one).id)
+    assert_not thanking.valid?
+  end
+
+  test 'thanking_id must be associated exist thanking' do
+    thanking_ids = thankings.map(&:id)
+    not_exist_thanking_id = generate_not_repeatable_id(thanking_ids)
+
+    lending_thanking = LendingThanking.new(lending_id: lendings(:one).id, thanking_id: not_exist_thanking_id)
+    assert_not lending_thanking.valid?
+  end
+
+  private
+
+  # fixtureのデータと被らないidを生成するためのメソッド
+  def generate_not_repeatable_id(exist_ids)
+    not_repeatable_id = nil
+    loop do
+      not_repeatable_id = rand(1..exist_ids.length)
+      break unless exist_ids.include?(not_repeatable_id)
+    end
+    not_repeatable_id
+  end
 end

--- a/test/models/lending_thanking_test.rb
+++ b/test/models/lending_thanking_test.rb
@@ -2,17 +2,17 @@ require 'test_helper'
 
 class LendingThankingTest < ActiveSupport::TestCase
   test 'valid LendingThanking model' do
-    lending_thanking = LendingThanking.new(lending_id: lendings(:one).id, thanking_id: thankings(:one).id)
+    lending_thanking = LendingThanking.new(lending: lendings(:one), thanking: thankings(:one))
     assert lending_thanking.valid?
   end
 
   test 'lending_id must be presence' do
-    lending_thanking = LendingThanking.new(thanking_id: thankings(:one).id)
+    lending_thanking = LendingThanking.new(thanking: thankings(:one))
     assert_not lending_thanking.valid?
   end
 
   test 'thanking_id must be presence' do
-    lending_thanking = LendingThanking.new(lending_id: lendings(:one).id)
+    lending_thanking = LendingThanking.new(lending: lendings(:one))
     assert_not lending_thanking.valid?
   end
 

--- a/test/models/lending_thanking_test.rb
+++ b/test/models/lending_thanking_test.rb
@@ -17,30 +17,14 @@ class LendingThankingTest < ActiveSupport::TestCase
   end
 
   test 'lending_id must be associated exist lending' do
-    lending_ids = lendings.map(&:id)
-    not_exist_lending_id = generate_not_repeatable_id(lending_ids)
-
+    not_exist_lending_id = lendings.map(&:id).max + 1
     thanking = LendingThanking.new(lending_id: not_exist_lending_id, thanking_id: thankings(:one).id)
     assert_not thanking.valid?
   end
 
   test 'thanking_id must be associated exist thanking' do
-    thanking_ids = thankings.map(&:id)
-    not_exist_thanking_id = generate_not_repeatable_id(thanking_ids)
-
+    not_exist_thanking_id = thankings.map(&:id).max + 1
     lending_thanking = LendingThanking.new(lending_id: lendings(:one).id, thanking_id: not_exist_thanking_id)
     assert_not lending_thanking.valid?
-  end
-
-  private
-
-  # fixtureのデータと被らないidを生成するためのメソッド
-  def generate_not_repeatable_id(exist_ids)
-    not_repeatable_id = nil
-    loop do
-      not_repeatable_id = rand(1..exist_ids.length)
-      break unless exist_ids.include?(not_repeatable_id)
-    end
-    not_repeatable_id
   end
 end

--- a/test/models/lending_thanking_test.rb
+++ b/test/models/lending_thanking_test.rb
@@ -1,0 +1,8 @@
+require 'test_helper'
+
+class LendingThankingTest < ActiveSupport::TestCase
+  test 'valid LendingThanking model' do
+    lending_thanking = LendingThanking.new(lending_id: lendings(:one).id, thanking_id: thankings(:one).id)
+    assert lending_thanking.valid?
+  end
+end

--- a/test/models/thanking_test.rb
+++ b/test/models/thanking_test.rb
@@ -5,4 +5,19 @@ class ThankingTest < ActiveSupport::TestCase
     thanking = Thanking.new(name: 'ice', url: 'https://example.com', lending_id: lendings(:one).id)
     assert thanking.valid?
   end
+
+  test 'name must be presence' do
+    thanking = Thanking.new(url: 'https://example.com', lending_id: lendings(:one).id)
+    assert_not thanking.valid?
+  end
+
+  test 'url must be presence' do
+    thanking = Thanking.new(name: 'ice', lending_id: lendings(:one).id)
+    assert_not thanking.valid?
+  end
+
+  test 'lending_id must be presence' do
+    thanking = Thanking.new(name: 'ice', url: 'https://example.com')
+    assert_not thanking.valid?
+  end
 end

--- a/test/models/thanking_test.rb
+++ b/test/models/thanking_test.rb
@@ -1,0 +1,8 @@
+require 'test_helper'
+
+class ThankingTest < ActiveSupport::TestCase
+  test 'valid Thanking model' do
+    thanking = Thanking.new(name: 'ice', url: 'https://example.com', lending_id: lendings(:one).id)
+    assert thanking.valid?
+  end
+end

--- a/test/models/thanking_test.rb
+++ b/test/models/thanking_test.rb
@@ -2,22 +2,17 @@ require 'test_helper'
 
 class ThankingTest < ActiveSupport::TestCase
   test 'valid Thanking model' do
-    thanking = Thanking.new(name: 'ice', url: 'https://example.com', lending_id: lendings(:one).id)
+    thanking = Thanking.new(name: 'ice', url: 'https://example.com')
     assert thanking.valid?
   end
 
   test 'name must be presence' do
-    thanking = Thanking.new(url: 'https://example.com', lending_id: lendings(:one).id)
+    thanking = Thanking.new(url: 'https://example.com')
     assert_not thanking.valid?
   end
 
   test 'url must be presence' do
-    thanking = Thanking.new(name: 'ice', lending_id: lendings(:one).id)
-    assert_not thanking.valid?
-  end
-
-  test 'lending_id must be presence' do
-    thanking = Thanking.new(name: 'ice', url: 'https://example.com')
+    thanking = Thanking.new(name: 'ice')
     assert_not thanking.valid?
   end
 end


### PR DESCRIPTION
## 実装の背景・目的
バリデーションが期待通りに動作することを保証するために、Thanking, LendingThankingモデルのバリデーションテストを作成しました

## やったこと
- `rails g`でfixturesを自動生成
- [Thankingモデルのバリデーションテストの作成](test/models/thanking_test.rb)
- [LendingThankingモデルのバリデーションテストの作成](test/models/lending_thanking_test.rb)

## キャプチャ

## 補足
- `lending_thanking_test.rb`で存在しないLendingやThankingのidを持つレコードを作成できないことをテストしているのですが、fixturesで作られたデータに存在しないidを作るために`generate_not_repeatable_id `というメソッドを使っています。これはやり方として適切でしょうか？