### PR TITLE
返却時にお礼をサジェストする機能を追加した

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -43,7 +43,7 @@ class WebhookController < ApplicationController
 
                 lending_count = Lending.not_returned.where(borrower_id: borrower_id, lender_name: lender_name).count
                 thanking = Thanking.random_choice
-                LendingThanking.create!(lending_id: lending.id, thanking_id: thanking.id)
+                LendingThanking.create!(lending: lending, thanking: thanking)
 
                 render_to_string partial: 'on_returned_message', locals: {
                   lending: lending,

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -39,11 +39,17 @@ class WebhookController < ApplicationController
 
               elsif action == "返した" && lender_name && content
                 lending = Lending.not_returned.find_by!(borrower_id: borrower_id, lender_name: lender_name, content: content)
-
                 lending.return_content!
 
                 lending_count = Lending.not_returned.where(borrower_id: borrower_id, lender_name: lender_name).count
-                "#{lender_name}さんに#{content}を返しました！\n#{lender_name}さんには計#{lending_count}個の借りがあります。"
+                thanking = Thanking.random_choice
+                LendingThanking.create!(lending_id: lending.id, thanking_id: thanking.id)
+
+                render_to_string partial: 'on_returned_message', locals: {
+                  lending: lending,
+                  lending_count: lending_count,
+                  thanking: thanking
+                }
 
               else
                 raise ArgumentError

--- a/app/models/thanking.rb
+++ b/app/models/thanking.rb
@@ -4,7 +4,7 @@ class Thanking < ApplicationRecord
 
   validates :name, :url, presence: true
 
-  scope :random_choice, -> {
-    find(Thanking.pluck(:id).sample)
-  }
+  def self.random_choice
+    Thanking.find(Thanking.pluck(:id).sample)
+  end
 end

--- a/app/models/thanking.rb
+++ b/app/models/thanking.rb
@@ -3,4 +3,8 @@ class Thanking < ApplicationRecord
   has_many :lendings, through: :lending_thankings
 
   validates :name, :url, presence: true
+
+  scope :random_choice, -> {
+    find(Thanking.pluck(:id).sample)
+  }
 end

--- a/app/views/webhook/_on_returned_message.erb
+++ b/app/views/webhook/_on_returned_message.erb
@@ -1,0 +1,4 @@
+<%= lending.lender_name %>さんに<%= lending.content %>を返しました！
+<%= lending.lender_name %>さんには計<%= lending_count %>個の借りがあります。
+貸してくれたお礼に、<%= lending.lender_name %>さんに「<%= thanking.name %>」を送りませんか？
+<%= thanking.url %>


### PR DESCRIPTION
## 実装の背景・目的
[機能仕様レベル3](https://giftee.docbase.io/posts/1909435#%E6%A9%9F%E8%83%BD%E4%BB%95%E6%A7%98%E3%83%AC%E3%83%99%E3%83%AB3-%E4%BB%BB%E6%84%8F)の「返したことを報告した際、そのお礼をランダムにボットからサジェスト」を実装しました

## やったこと
- Thankingモデルに、ランダムに一つレコードを取得するscopeを追加
- LendingとThankingを関連づけるLendingThankingを保存するようにした
- レスポンスメッセージに、ランダムに取得したThankingを含めるようにした
- 返却時のレスポンスメッセージが長くなってきたのでviewファイルに移した

## キャプチャ
![Screenshot_20210528-142911_LINE.jpg](https://user-images.githubusercontent.com/54694030/119934713-309b2780-bfc1-11eb-9294-2e9609d5186a.jpg)

## 補足
