### PR TITLE
lender_nameの後ろの'さん'を削除しました

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -30,7 +30,7 @@ class WebhookController < ApplicationController
                 Lending.create!(borrower_id: borrower_id, lender_name: lender_name, content: content)
 
                 lending_count = Lending.not_returned.where(borrower_id: borrower_id, lender_name: lender_name).count
-                "#{lender_name}さんに#{content}を借りました！\n#{lender_name}さんには計#{lending_count}個の借りがあります。"
+                "#{lender_name}に#{content}を借りました！\n#{lender_name}には計#{lending_count}個の借りがあります。"
 
               elsif action == "一覧"
                 per_lender_content_counts = Lending.not_returned.where(borrower_id: borrower_id).count_per_lender_content

--- a/app/views/webhook/_on_returned_message.erb
+++ b/app/views/webhook/_on_returned_message.erb
@@ -1,4 +1,4 @@
-<%= lending.lender_name %>さんに<%= lending.content %>を返しました！
-<%= lending.lender_name %>さんには計<%= lending_count %>個の借りがあります。
-貸してくれたお礼に、<%= lending.lender_name %>さんに「<%= thanking.name %>」を送りませんか？
+<%= lending.lender_name %>に<%= lending.content %>を返しました！
+<%= lending.lender_name %>には計<%= lending_count %>個の借りがあります。
+貸してくれたお礼に、<%= lending.lender_name %>に「<%= thanking.name %>」を送りませんか？
 <%= thanking.url %>


### PR DESCRIPTION
## 実装の背景・目的
ユーザーが「〇〇さん」「〇〇くん」などをlender_nameに登録した際に後ろにさらに「さん」をつけると日本語がおかしくなるので、レスポンスメッセージのlender_nameの末尾の「さん」を削除した

## やったこと
- レスポンスメッセージのlender_nameの末尾の「さん」の削除

## キャプチャ

## 補足
