### PR TITLE
一覧の後にlender_nameが入力された場合はそのlenderから借りたものの一覧のみを返すようにした

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -33,9 +33,19 @@ class WebhookController < ApplicationController
                 "#{lender_name}さんに#{content}を借りました！\n#{lender_name}さんには計#{lending_count}個の借りがあります。"
 
               elsif action == "一覧"
-                per_lender_content_counts = Lending.not_returned.where(borrower_id: borrower_id).count_per_lender_content
-                lendings_per_lender_content = Lending.format_per_lender_content_count(per_lender_content_counts)
-                render_to_string partial: 'list_per_lender', locals: { lendings_per_lender_content: lendings_per_lender_content }
+                if lender_name
+                  render_to_string partial: 'list_per_content', locals: {
+                    lender_name: lender_name,
+                    per_content_counts: Lending.not_returned
+                                               .where(borrower_id: borrower_id, lender_name: lender_name)
+                                               .count_per_content
+                  }
+
+                else
+                  per_lender_content_counts = Lending.not_returned.where(borrower_id: borrower_id).count_per_lender_content
+                  lendings_per_lender_content = Lending.format_per_lender_content_count(per_lender_content_counts)
+                  render_to_string partial: 'list_per_lender', locals: { lendings_per_lender_content: lendings_per_lender_content }
+                end
 
               elsif action == "返した" && lender_name && content
                 lending = Lending.not_returned.find_by!(borrower_id: borrower_id, lender_name: lender_name, content: content)

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -32,20 +32,19 @@ class WebhookController < ApplicationController
                 lending_count = Lending.not_returned.where(borrower_id: borrower_id, lender_name: lender_name).count
                 "#{lender_name}さんに#{content}を借りました！\n#{lender_name}さんには計#{lending_count}個の借りがあります。"
 
-              elsif action == "一覧"
-                if lender_name
-                  render_to_string partial: 'list_per_content', locals: {
-                    lender_name: lender_name,
-                    per_content_counts: Lending.not_returned
-                                               .where(borrower_id: borrower_id, lender_name: lender_name)
-                                               .count_per_content
-                  }
+              elsif action == "一覧" && lender_name
+                per_content_counts = Lending.not_returned
+                                            .where(borrower_id: borrower_id, lender_name: lender_name)
+                                            .count_per_content
+                render_to_string partial: 'list_per_content', locals: {
+                  lender_name: lender_name,
+                  per_content_counts: per_content_counts
+                }
 
-                else
-                  per_lender_content_counts = Lending.not_returned.where(borrower_id: borrower_id).count_per_lender_content
-                  lendings_per_lender_content = Lending.format_per_lender_content_count(per_lender_content_counts)
-                  render_to_string partial: 'list_per_lender', locals: { lendings_per_lender_content: lendings_per_lender_content }
-                end
+              elsif action == "一覧"
+                per_lender_content_counts = Lending.not_returned.where(borrower_id: borrower_id).count_per_lender_content
+                lendings_per_lender_content = Lending.format_per_lender_content_count(per_lender_content_counts)
+                render_to_string partial: 'list_per_lender', locals: { lendings_per_lender_content: lendings_per_lender_content }
 
               elsif action == "返した" && lender_name && content
                 lending = Lending.not_returned.find_by!(borrower_id: borrower_id, lender_name: lender_name, content: content)

--- a/app/models/lending.rb
+++ b/app/models/lending.rb
@@ -10,6 +10,10 @@ class Lending < ApplicationRecord
     group(:lender_name, :content).select("lender_name, content, count(*)")
   }
 
+  scope :count_per_content, -> {
+    group(:content).select('content, count(*)')
+  }
+
   def return_content!
     update!(has_returned: true)
   end

--- a/app/views/webhook/_list_per_content.erb
+++ b/app/views/webhook/_list_per_content.erb
@@ -1,3 +1,3 @@
 <% total_count = per_content_counts.inject(0) { |result, content_count| result + content_count.count } %>
-<%= lender_name %>さんには<%= total_count %>個の借りがあります。
+<%= lender_name %>には<%= total_count %>個の借りがあります。
 <%= per_content_counts.map { |content_count| "- #{content_count.content}　#{content_count.count}個" }.join("\n") %>

--- a/app/views/webhook/_list_per_content.erb
+++ b/app/views/webhook/_list_per_content.erb
@@ -1,0 +1,3 @@
+<% total_count = per_content_counts.inject(0) { |result, content_count| result + content_count.count } %>
+<%= lender_name %>さんには<%= total_count %>個の借りがあります。
+<%= per_content_counts.map { |content_count| "- #{content_count.content}　#{content_count.count}個" }.join("\n") %>


### PR DESCRIPTION
## 実装の背景・目的
[機能仕様レベル3](https://giftee.docbase.io/posts/1909435#%E6%A9%9F%E8%83%BD%E4%BB%95%E6%A7%98%E3%83%AC%E3%83%99%E3%83%AB3-%E4%BB%BB%E6%84%8F)の「借りた相手ごとの借りたものの一覧を取得」を実装しました

## やったこと
- 一覧の後にlender_nameが指定されていた場合の条件分岐の作成
- 上記の場合はそのlenderから借りているもののみを返すようにした


## キャプチャ
![スクリーンショット 2021-05-28 15 25 44](https://user-images.githubusercontent.com/54694030/119939527-fafa3c80-bfc8-11eb-8db2-10014c3ccb35.png)

## 補足

